### PR TITLE
feat: implement canvas export functionality with image and video 

### DIFF
--- a/test-app/src/components/studio/BackgroundStudio.tsx
+++ b/test-app/src/components/studio/BackgroundStudio.tsx
@@ -10,6 +10,8 @@ import type { BackgroundId, AnyParams } from "./types";
 import { BACKGROUNDS, buildInitialParamMap } from "./backgrounds";
 import { Sidebar } from "./Sidebar";
 import { ExportModal } from "./ExportModal";
+import { useCanvasExport } from "./useCanvasExport";
+import { CanvasExportTabs } from "./CanvasExportTabs";
 import { Navbar } from "../layout/Navbar";
 import { DemoContentOverlay } from "../shared/DemoContentOverlay";
 
@@ -24,11 +26,18 @@ export function BackgroundStudio({ initialBg }: { initialBg?: string } = {}) {
   const [searchQuery, setSearchQuery] = useState("");
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [exportOpen, setExportOpen] = useState(false);
-  const [canvasTab, setCanvasTab] = useState<"image" | "div-video">("image");
   const [showContent, setShowContent] = useState(false);
 
   const bg = BACKGROUNDS.find((b) => b.id === activeId)!;
   const params = paramMap[activeId];
+  const {
+    previewRef,
+    isDownloadingImage,
+    isRecordingVideo,
+    recordingCountdown,
+    handleDownloadImage,
+    handleVideoAction,
+  } = useCanvasExport(bg.id, params.seed as number | string | undefined);
 
   const handleParamChange = useCallback(
     (name: string, value: number | string | boolean) => {
@@ -69,6 +78,7 @@ export function BackgroundStudio({ initialBg }: { initialBg?: string } = {}) {
         <Sidebar
           bg={bg}
           params={params}
+          isDisabled={isRecordingVideo}
           activeId={activeId}
           dropdownOpen={dropdownOpen}
           searchQuery={searchQuery}
@@ -85,7 +95,10 @@ export function BackgroundStudio({ initialBg }: { initialBg?: string } = {}) {
         {/* Canvas area */}
         <div className="flex-1 flex flex-col overflow-hidden pt-2 p-4 gap-3">
           {/* Canvas card */}
-          <div className="studio-in-1 flex-1 relative overflow-hidden rounded-xl">
+          <div
+            ref={previewRef}
+            className="studio-in-1 flex-1 relative overflow-hidden rounded-xl"
+          >
             <bg.Component
               {...params}
               style={{
@@ -100,21 +113,13 @@ export function BackgroundStudio({ initialBg }: { initialBg?: string } = {}) {
 
           {/* Bottom bar: tabs left, demo toggle right */}
           <div className="studio-in-2 shrink-0 flex items-center justify-between px-1">
-            <div className="flex items-center gap-0.5">
-              {(["image", "div-video"] as const).map((tab) => (
-                <button
-                  key={tab}
-                  onClick={() => setCanvasTab(tab)}
-                  className={`text-[12px] font-sans px-3 py-1.5 rounded-md cursor-pointer border-none transition-colors ${
-                    canvasTab === tab
-                      ? "bg-faint text-ink"
-                      : "bg-transparent text-muted hover:text-ink"
-                  }`}
-                >
-                  {tab === "image" ? "Image" : "Video"}
-                </button>
-              ))}
-            </div>
+            <CanvasExportTabs
+              isDownloadingImage={isDownloadingImage}
+              isRecordingVideo={isRecordingVideo}
+              recordingCountdown={recordingCountdown}
+              onDownloadImage={handleDownloadImage}
+              onVideoAction={handleVideoAction}
+            />
 
             <div className="flex items-center gap-2.5">
               <span className="text-[12px] font-sans text-muted">

--- a/test-app/src/components/studio/CanvasExportTabs.tsx
+++ b/test-app/src/components/studio/CanvasExportTabs.tsx
@@ -1,0 +1,52 @@
+interface CanvasExportTabsProps {
+  isDownloadingImage: boolean;
+  isRecordingVideo: boolean;
+  recordingCountdown: number | null;
+  onDownloadImage: () => Promise<void>;
+  onVideoAction: () => Promise<void>;
+}
+
+export function CanvasExportTabs({
+  isDownloadingImage,
+  isRecordingVideo,
+  recordingCountdown,
+  onDownloadImage,
+  onVideoAction,
+}: CanvasExportTabsProps) {
+  return (
+    <div className="flex items-center gap-0.5">
+      {(["image", "div-video"] as const).map((tab) => (
+        <div key={tab} className="relative group">
+          <button
+            onClick={tab === "image" ? onDownloadImage : onVideoAction}
+            disabled={tab === "image" ? isDownloadingImage : false}
+            className={`text-[12px] font-sans px-3 py-1.5 rounded-md cursor-pointer border-none transition-colors bg-transparent text-muted hover:text-ink ${
+              tab === "image" && isDownloadingImage
+                ? "opacity-60 cursor-wait"
+                : ""
+            } ${
+              tab === "div-video" && isRecordingVideo
+                ? "text-ink"
+                : ""
+            }`}
+          >
+            {tab === "image"
+              ? isDownloadingImage
+                ? "Downloading..."
+                : "Image"
+              : isRecordingVideo
+                ? `Cancel (${recordingCountdown ?? 0})`
+                : "Video"}
+          </button>
+          <div className="pointer-events-none absolute bottom-full left-0 z-20 mb-1.5 w-36 rounded-md bg-faint px-2 py-1.5 text-[10px] leading-tight text-ink opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100">
+            {tab === "image"
+              ? "Click to download this background as an image"
+              : isRecordingVideo
+                ? "Click again to cancel recording"
+                : "Click to download this background as a 10s video"}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/test-app/src/components/studio/Sidebar.tsx
+++ b/test-app/src/components/studio/Sidebar.tsx
@@ -14,6 +14,7 @@ import {
 interface SidebarProps {
   bg: BackgroundEntry;
   params: AnyParams;
+  isDisabled?: boolean;
   activeId: BackgroundId;
   dropdownOpen: boolean;
   searchQuery: string;
@@ -30,6 +31,7 @@ interface SidebarProps {
 export function Sidebar({
   bg,
   params,
+  isDisabled = false,
   activeId,
   dropdownOpen,
   searchQuery,
@@ -42,7 +44,17 @@ export function Sidebar({
   onExport,
 }: SidebarProps) {
   return (
-    <aside className="studio-side-in w-64 ml-4 shrink-0 bg-bg flex flex-col">
+    <aside
+      aria-disabled={isDisabled}
+      className={`studio-side-in relative w-64 ml-4 shrink-0 bg-bg flex flex-col ${isDisabled ? "opacity-70" : ""}`}
+    >
+      {isDisabled && (
+        <div
+          className="absolute inset-0 z-20 cursor-not-allowed"
+          title="Controls are disabled while recording video"
+        />
+      )}
+
       {/* Header */}
       <div className="flex items-center justify-between mx-4 py-4 border-b border-border shrink-0">
         <div className="flex items-center gap-2">

--- a/test-app/src/components/studio/useCanvasExport.ts
+++ b/test-app/src/components/studio/useCanvasExport.ts
@@ -1,0 +1,243 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type RefObject,
+} from "react";
+
+interface UseCanvasExportResult {
+  previewRef: RefObject<HTMLDivElement | null>;
+  isDownloadingImage: boolean;
+  isRecordingVideo: boolean;
+  recordingCountdown: number | null;
+  handleDownloadImage: () => Promise<void>;
+  handleVideoAction: () => Promise<void>;
+}
+
+function getBestVideoMimeType() {
+  if (typeof MediaRecorder === "undefined") return null;
+
+  const candidates = [
+    "video/webm;codecs=av01",
+    "video/webm;codecs=vp9",
+    "video/webm;codecs=vp8",
+    "video/webm",
+  ];
+
+  return candidates.find((type) => MediaRecorder.isTypeSupported(type)) ?? null;
+}
+
+function sanitizeSeed(seed: number | string | undefined) {
+  const value = String(seed ?? "unknown").trim();
+  return value.length > 0 ? value.replace(/[^a-zA-Z0-9_-]/g, "_") : "unknown";
+}
+
+function downloadBlob(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  window.setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+export function useCanvasExport(
+  bgId: string,
+  seed: number | string | undefined,
+): UseCanvasExportResult {
+  const [isDownloadingImage, setIsDownloadingImage] = useState(false);
+  const [isRecordingVideo, setIsRecordingVideo] = useState(false);
+  const [recordingCountdown, setRecordingCountdown] = useState<number | null>(
+    null,
+  );
+
+  const previewRef = useRef<HTMLDivElement | null>(null);
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const mediaStreamRef = useRef<MediaStream | null>(null);
+  const stopTimeoutRef = useRef<number | null>(null);
+  const countdownIntervalRef = useRef<number | null>(null);
+  const canceledRef = useRef(false);
+
+  const getPreviewCanvas = useCallback(() => {
+    return previewRef.current?.querySelector("canvas") ?? null;
+  }, []);
+
+  const buildFileBaseName = useCallback(() => {
+    return `${bgId}_${sanitizeSeed(seed)}`;
+  }, [bgId, seed]);
+
+  const clearRecordingTimers = useCallback(() => {
+    if (stopTimeoutRef.current !== null) {
+      window.clearTimeout(stopTimeoutRef.current);
+      stopTimeoutRef.current = null;
+    }
+    if (countdownIntervalRef.current !== null) {
+      window.clearInterval(countdownIntervalRef.current);
+      countdownIntervalRef.current = null;
+    }
+  }, []);
+
+  const cleanupRecorderResources = useCallback(() => {
+    clearRecordingTimers();
+    const stream = mediaStreamRef.current;
+    if (stream) {
+      stream.getTracks().forEach((track) => track.stop());
+      mediaStreamRef.current = null;
+    }
+    mediaRecorderRef.current = null;
+    setIsRecordingVideo(false);
+    setRecordingCountdown(null);
+  }, [clearRecordingTimers]);
+
+  const handleDownloadImage = useCallback(async () => {
+    if (isDownloadingImage) return;
+
+    const canvas = getPreviewCanvas();
+    if (!canvas) {
+      window.alert("Canvas not available yet. Please try again in a second.");
+      return;
+    }
+
+    setIsDownloadingImage(true);
+    try {
+      const blob = await new Promise<Blob>((resolve, reject) => {
+        canvas.toBlob((result) => {
+          if (!result) {
+            reject(new Error("Could not generate PNG from canvas."));
+            return;
+          }
+          resolve(result);
+        }, "image/png");
+      });
+
+      downloadBlob(blob, `${buildFileBaseName()}.png`);
+    } catch (error) {
+      console.error(error);
+      window.alert("Image export failed. Please try again.");
+    } finally {
+      setIsDownloadingImage(false);
+    }
+  }, [buildFileBaseName, getPreviewCanvas, isDownloadingImage]);
+
+  const handleDownloadVideo = useCallback(async () => {
+    if (isRecordingVideo) return;
+
+    const canvas = getPreviewCanvas();
+    if (!canvas) {
+      window.alert("Canvas not available yet. Please try again in a second.");
+      return;
+    }
+
+    if (typeof canvas.captureStream !== "function") {
+      window.alert("Video export is not supported in this browser.");
+      return;
+    }
+
+    const mimeType = getBestVideoMimeType();
+    if (!mimeType) {
+      window.alert("Video export is not supported in this browser.");
+      return;
+    }
+
+    const stream = canvas.captureStream(60);
+    const chunks: BlobPart[] = [];
+
+    canceledRef.current = false;
+    setIsRecordingVideo(true);
+    setRecordingCountdown(10);
+    try {
+      const recorder = new MediaRecorder(stream, {
+        mimeType,
+        videoBitsPerSecond: 20_000_000,
+      });
+      mediaRecorderRef.current = recorder;
+      mediaStreamRef.current = stream;
+
+      const blobPromise = new Promise<Blob>((resolve, reject) => {
+        recorder!.ondataavailable = (event: BlobEvent) => {
+          if (event.data.size > 0) chunks.push(event.data);
+        };
+
+        recorder!.onerror = () => {
+          reject(new Error("MediaRecorder failed."));
+        };
+
+        recorder!.onstop = () => {
+          resolve(new Blob(chunks, { type: mimeType }));
+        };
+      });
+
+      recorder.start(250);
+      countdownIntervalRef.current = window.setInterval(() => {
+        setRecordingCountdown((prev) => {
+          if (prev === null) return prev;
+          return prev > 0 ? prev - 1 : 0;
+        });
+      }, 1000);
+
+      stopTimeoutRef.current = window.setTimeout(() => {
+        if (recorder && recorder.state !== "inactive") {
+          recorder.stop();
+        }
+      }, 10_000);
+
+      const blob = await blobPromise;
+      if (!canceledRef.current) {
+        const extension = mimeType.includes("mp4") ? "mp4" : "webm";
+        downloadBlob(blob, `${buildFileBaseName()}.${extension}`);
+      }
+    } catch (error) {
+      console.error(error);
+      window.alert("Video export failed. Please try again.");
+    } finally {
+      cleanupRecorderResources();
+    }
+  }, [
+    buildFileBaseName,
+    cleanupRecorderResources,
+    getPreviewCanvas,
+    isRecordingVideo,
+  ]);
+
+  const cancelVideoRecording = useCallback(async () => {
+    if (!isRecordingVideo) return;
+    canceledRef.current = true;
+    const recorder = mediaRecorderRef.current;
+    if (recorder && recorder.state !== "inactive") {
+      recorder.stop();
+      return;
+    }
+    cleanupRecorderResources();
+  }, [cleanupRecorderResources, isRecordingVideo]);
+
+  const handleVideoAction = useCallback(async () => {
+    if (isRecordingVideo) {
+      await cancelVideoRecording();
+      return;
+    }
+    await handleDownloadVideo();
+  }, [cancelVideoRecording, handleDownloadVideo, isRecordingVideo]);
+
+  useEffect(() => {
+    return () => {
+      canceledRef.current = true;
+      const recorder = mediaRecorderRef.current;
+      if (recorder && recorder.state !== "inactive") {
+        recorder.stop();
+      }
+      cleanupRecorderResources();
+    };
+  }, [cleanupRecorderResources]);
+
+  return {
+    previewRef,
+    isDownloadingImage,
+    isRecordingVideo,
+    recordingCountdown,
+    handleDownloadImage,
+    handleVideoAction,
+  };
+}


### PR DESCRIPTION
This pull request adds robust image and video export functionality to the `BackgroundStudio` component, improving the user experience for exporting canvas backgrounds. The export logic is modularized into a new custom hook, and the UI is updated to reflect export states and prevent conflicting actions during video recording.

**Export functionality enhancements:**

* Added a new `useCanvasExport` hook to encapsulate all logic for exporting the canvas as an image or a 10-second video, including browser compatibility checks, file naming, download handling, and recording state management.
* Introduced the `CanvasExportTabs` component, which provides clear UI for image and video export actions, displays progress/status, and disables controls appropriately during ongoing exports. [[1]](diffhunk://#diff-74334c657b1423372e364f20b02e7fc8d58d213a05276182664628c2a4ebdc2aR1-R52) [[2]](diffhunk://#diff-e7973467591917d6f1770842e79665b8b60ab71fec09a573072a970115fbf7e7L103-R122)

**UI/UX improvements and integration:**

* Updated `BackgroundStudio.tsx` to use the new export hook and tabs, wiring up all relevant state and handlers, and ensuring the canvas DOM node is referenced for export operations. [[1]](diffhunk://#diff-e7973467591917d6f1770842e79665b8b60ab71fec09a573072a970115fbf7e7R13-R14) [[2]](diffhunk://#diff-e7973467591917d6f1770842e79665b8b60ab71fec09a573072a970115fbf7e7L27-R40) [[3]](diffhunk://#diff-e7973467591917d6f1770842e79665b8b60ab71fec09a573072a970115fbf7e7L88-R101)
* Modified the `Sidebar` component to accept an `isDisabled` prop, visually and functionally disabling sidebar controls while video recording is in progress to prevent user actions that could interfere with the export. [[1]](diffhunk://#diff-1d3bbb9611fb7644cdc35e23cf687abd34864fa7f5cde711d4f84798c705b138R17) [[2]](diffhunk://#diff-1d3bbb9611fb7644cdc35e23cf687abd34864fa7f5cde711d4f84798c705b138R34) [[3]](diffhunk://#diff-1d3bbb9611fb7644cdc35e23cf687abd34864fa7f5cde711d4f84798c705b138L45-R57)
* Passed the `isRecordingVideo` state from the export hook to the `Sidebar` to synchronize UI disabling during video recording.

These changes collectively provide a more reliable and user-friendly way to export backgrounds, with clear feedback and prevention of conflicting actions during export processes. 

#8 