### PR TITLE
feat: add per-background URL routing for Studio and Docs

### DIFF
--- a/test-app/src/App.tsx
+++ b/test-app/src/App.tsx
@@ -6,6 +6,7 @@ import { StudioPage } from "./pages/StudioPage";
 import { DocsPage } from "./pages/DocsPage";
 import { useState, useEffect } from "react";
 import { ROUTES } from "./lib/constants";
+import { matchRoute } from "./lib/routing";
 
 export default function App() {
   const [currentPath, setCurrentPath] = useState(window.location.pathname);
@@ -18,12 +19,15 @@ export default function App() {
     return () => window.removeEventListener("popstate", handlePopState);
   }, []);
 
-  if (currentPath === ROUTES.studio) {
-    return <StudioPage />;
+  const studioMatch = matchRoute(ROUTES.studioBackground, currentPath);
+  const docsMatch   = matchRoute(ROUTES.docsBackground, currentPath);
+
+  if (currentPath === ROUTES.studio || currentPath === "/Studio" || studioMatch) {
+    return <StudioPage key={currentPath} backgroundId={studioMatch?.id} />;
   }
 
-  if (currentPath === ROUTES.docs) {
-    return <DocsPage />;
+  if (currentPath === ROUTES.docs || docsMatch) {
+    return <DocsPage key={currentPath} backgroundId={docsMatch?.id} />;
   }
 
   return (

--- a/test-app/src/components/docs/BackgroundDocCard.tsx
+++ b/test-app/src/components/docs/BackgroundDocCard.tsx
@@ -5,7 +5,7 @@ import { PropsTable } from "./PropsTable";
 import { CodeBlock } from "./CodeBlock";
 import { generateSnippet } from "./generateSnippet";
 import { navigate } from "../../lib/navigate";
-import { ROUTES } from "../../lib/constants";
+import { studioRoute } from "../../lib/constants";
 
 export function BackgroundDocCard({ entry }: { entry: DocEntry }) {
   const [params, setParams] = useState<Record<string, unknown>>(() => ({
@@ -134,7 +134,7 @@ export function BackgroundDocCard({ entry }: { entry: DocEntry }) {
       {/* Action row */}
       <div className="flex items-center gap-3 px-6 py-4 border-b border-border">
         <button
-          onClick={() => navigate(ROUTES.studio)}
+          onClick={() => navigate(studioRoute(entry.id))}
           className="flex items-center gap-1.5 px-4 py-2 bg-accent rounded-lg text-[#1a1a1a] text-[13px] font-semibold font-display hover:opacity-90 transition-opacity cursor-pointer border-0"
         >
           Open in Studio

--- a/test-app/src/components/docs/BackgroundView.tsx
+++ b/test-app/src/components/docs/BackgroundView.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import type { DocEntry } from "./registry";
 import { navigate } from "../../lib/navigate";
-import { ROUTES, CLI_PACKAGE } from "../../lib/constants";
+import { studioRoute, CLI_PACKAGE } from "../../lib/constants";
 import { PropsTable } from "./PropsTable";
 import { CodeBlock } from "./CodeBlock";
 import { generateFullSnippet } from "./generateSnippet";
@@ -94,10 +94,7 @@ export function BackgroundView({
           ))}
         </div>
         <button
-          onClick={() => {
-            sessionStorage.setItem("studio-initial-bg", entry.id);
-            navigate(ROUTES.studio);
-          }}
+          onClick={() => navigate(studioRoute(entry.id))}
           className="flex items-center gap-1 px-2.5 py-1.25 text-[12px] rounded-md text-[#1a1a1a] font-semibold font-display bg-accent hover:opacity-90 transition-opacity cursor-pointer border-0 mb-px"
         >
           Open in Studio

--- a/test-app/src/components/docs/DocsSection.tsx
+++ b/test-app/src/components/docs/DocsSection.tsx
@@ -5,10 +5,16 @@ import { IntroductionView } from "./IntroductionView";
 import { InstallationView } from "./InstallationView";
 import { BackgroundView } from "./BackgroundView";
 import { DOC_REGISTRY } from "./registry";
+import { navigate } from "../../lib/navigate";
+import { docsRoute, ROUTES } from "../../lib/constants";
 
-export function DocsSection() {
-  const [activePage, setActivePage] = useState("introduction");
-  const [params, setParams] = useState<Record<string, unknown>>({});
+export function DocsSection({ backgroundId }: { backgroundId?: string }) {
+  const initialPage = backgroundId ? `bg-${backgroundId}` : "introduction";
+  const [activePage, setActivePage] = useState(initialPage);
+  const initialEntry = DOC_REGISTRY.find((e) => `bg-${e.id}` === initialPage);
+  const [params, setParams] = useState<Record<string, unknown>>(
+    initialEntry ? { ...initialEntry.defaults } : {}
+  );
 
   const bgEntry = DOC_REGISTRY.find((e) => `bg-${e.id}` === activePage);
 
@@ -16,6 +22,8 @@ export function DocsSection() {
     const entry = DOC_REGISTRY.find((e) => `bg-${e.id}` === page);
     setActivePage(page);
     setParams(entry ? { ...entry.defaults } : {});
+    const bgId = page.startsWith("bg-") ? page.slice(3) : null;
+    navigate(bgId ? docsRoute(bgId) : ROUTES.docs + "/" + page);
   }, []);
 
   const handleParamChange = useCallback((name: string, value: unknown) => {

--- a/test-app/src/components/studio/BackgroundStudio.tsx
+++ b/test-app/src/components/studio/BackgroundStudio.tsx
@@ -14,6 +14,8 @@ import { useCanvasExport } from "./useCanvasExport";
 import { CanvasExportTabs } from "./CanvasExportTabs";
 import { Navbar } from "../layout/Navbar";
 import { DemoContentOverlay } from "../shared/DemoContentOverlay";
+import { navigate } from "../../lib/navigate";
+import { studioRoute } from "../../lib/constants";
 
 export function BackgroundStudio({ initialBg }: { initialBg?: string } = {}) {
   const [activeId, setActiveId] = useState<BackgroundId>(
@@ -61,6 +63,7 @@ export function BackgroundStudio({ initialBg }: { initialBg?: string } = {}) {
     setActiveId(id);
     setDropdownOpen(false);
     setSearchQuery("");
+    navigate(studioRoute(id));
   };
 
   const filtered = BACKGROUNDS.filter(

--- a/test-app/src/components/studio/Sidebar.tsx
+++ b/test-app/src/components/studio/Sidebar.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import type { ParamSchema } from "alg-art-backgrounds";
 import type { BackgroundEntry, AnyParams, BackgroundId } from "./types";
 import {
@@ -43,6 +44,8 @@ export function Sidebar({
   onReset,
   onExport,
 }: SidebarProps) {
+  const [copied, setCopied] = useState(false);
+
   return (
     <aside
       aria-disabled={isDisabled}
@@ -178,10 +181,14 @@ export function Sidebar({
             ↺ Reset
           </button>
           <button
-            onClick={() => navigator.clipboard.writeText(window.location.href)}
-            className="flex-1 flex items-center justify-center gap-1 bg-transparent border border-border rounded-lg text-[12px] text-muted py-2 cursor-pointer hover:text-ink hover:border-border-hover transition-colors font-sans"
+            onClick={() => {
+              navigator.clipboard.writeText(window.location.href);
+              setCopied(true);
+              setTimeout(() => setCopied(false), 1500);
+            }}
+            className={`flex-1 flex items-center justify-center gap-1 bg-transparent border border-border rounded-lg text-[12px] py-2 cursor-pointer hover:border-border-hover transition-colors font-sans ${copied ? "text-green" : "text-muted hover:text-ink"}`}
           >
-            ⤴ Share
+            {copied ? "copied ✓" : "⤴ Share"}
           </button>
         </div>
 

--- a/test-app/src/lib/constants.ts
+++ b/test-app/src/lib/constants.ts
@@ -1,8 +1,13 @@
 export const ROUTES = {
   home: "/",
-  studio: "/Studio",
+  studio: "/studio",
+  studioBackground: "/studio/:id",
   docs: "/docs",
+  docsBackground: "/docs/:id",
 } as const;
+
+export function studioRoute(id: string) { return `/studio/${id}`; }
+export function docsRoute(id: string)   { return `/docs/${id}`; }
 
 export const GITHUB_URL = "https://github.com/dano796/alg-art-backgrounds";
 

--- a/test-app/src/lib/routing.ts
+++ b/test-app/src/lib/routing.ts
@@ -1,0 +1,18 @@
+export function matchRoute(pattern: string, path: string): Record<string, string> | null {
+  const patternParts = pattern.split("/");
+  const pathParts = path.split("/");
+
+  if (patternParts.length !== pathParts.length) return null;
+
+  const params: Record<string, string> = {};
+
+  for (let i = 0; i < patternParts.length; i++) {
+    if (patternParts[i].startsWith(":")) {
+      params[patternParts[i].slice(1)] = pathParts[i];
+    } else if (patternParts[i] !== pathParts[i]) {
+      return null;
+    }
+  }
+
+  return params;
+}

--- a/test-app/src/pages/DocsPage.tsx
+++ b/test-app/src/pages/DocsPage.tsx
@@ -1,12 +1,12 @@
 import { Navbar } from "../components/layout/Navbar";
 import { DocsSection } from "../components/docs/DocsSection";
 
-export function DocsPage() {
+export function DocsPage({ backgroundId }: { backgroundId?: string }) {
   return (
     <div className="bg-bg min-h-svh">
       <Navbar />
       <div className="pt-14.5">
-        <DocsSection />
+        <DocsSection backgroundId={backgroundId} />
       </div>
     </div>
   );

--- a/test-app/src/pages/StudioPage.tsx
+++ b/test-app/src/pages/StudioPage.tsx
@@ -1,11 +1,9 @@
 import { BackgroundStudio } from "../components/studio/BackgroundStudio";
 
-export function StudioPage() {
-  const initialBg = sessionStorage.getItem("studio-initial-bg") ?? undefined;
-
+export function StudioPage({ backgroundId }: { backgroundId?: string }) {
   return (
     <div className="w-screen h-screen overflow-hidden">
-      <BackgroundStudio initialBg={initialBg} />
+      <BackgroundStudio initialBg={backgroundId} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Each background now has a canonical URL (`/studio/:id`, `/docs/:id`) — shareable and bookmark-friendly
- `App` uses a `matchRoute` helper to pass `backgroundId` to Studio and Docs pages
- Studio pushes URL on background selection; Docs pushes URL on sidebar navigation
- Browser back/forward buttons restore the previously selected background
- "Open in Studio" buttons navigate to the correct `/studio/:id` route
- Share button shows "copied ✓" feedback after clicking

Closes #7 