### PR TITLE
feat: migrate app animations to framer-motion

### DIFF
--- a/test-app/package-lock.json
+++ b/test-app/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@icons-pack/react-simple-icons": "^13.11.1",
+        "framer-motion": "^12.38.0",
         "lucide-react": "^1.7.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4"
@@ -2094,6 +2095,33 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/framer-motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
+      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.38.0",
+        "motion-utils": "^12.36.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2673,6 +2701,21 @@
         "node": "*"
       }
     },
+    "node_modules/motion-dom": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
+      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.36.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.36.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
+      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3067,9 +3110,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@icons-pack/react-simple-icons": "^13.11.1",
+    "framer-motion": "^12.38.0",
     "lucide-react": "^1.7.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"

--- a/test-app/src/App.tsx
+++ b/test-app/src/App.tsx
@@ -23,11 +23,11 @@ export default function App() {
   const docsMatch   = matchRoute(ROUTES.docsBackground, currentPath);
 
   if (currentPath === ROUTES.studio || currentPath === "/Studio" || studioMatch) {
-    return <StudioPage key={currentPath} backgroundId={studioMatch?.id} />;
+    return <StudioPage key="studio" backgroundId={studioMatch?.id} />;
   }
 
   if (currentPath === ROUTES.docs || docsMatch) {
-    return <DocsPage key={currentPath} backgroundId={docsMatch?.id} />;
+    return <DocsPage key="docs" backgroundId={docsMatch?.id} />;
   }
 
   return (

--- a/test-app/src/components/docs/BackgroundView.tsx
+++ b/test-app/src/components/docs/BackgroundView.tsx
@@ -43,12 +43,12 @@ export function BackgroundView({
   return (
     <div>
       {/* Title */}
-      <h1 className="docs-in font-display font-extrabold text-ink tracking-[-0.04em] leading-[1.05] mb-6 text-[clamp(28px,4vw,42px)]">
+      <h1 className="font-display font-extrabold text-ink tracking-[-0.04em] leading-[1.05] mb-6 text-[clamp(28px,4vw,42px)]">
         {entry.name}
       </h1>
 
       {/* Tab bar */}
-      <div className="docs-in-1 flex items-center justify-between border-b border-border">
+      <div className="flex items-center justify-between border-b border-border">
         <div className="flex items-center">
           {(["preview", "code"] as Tab[]).map((t) => (
             <button
@@ -70,7 +70,7 @@ export function BackgroundView({
       </div>
 
       {/* ── PREVIEW TAB ── */}
-      <div className={`docs-in-2 ${tab === "preview" ? "block" : "hidden"}`}>
+      <div className={tab === "preview" ? "block" : "hidden"}>
         {/* Canvas */}
         <div
           ref={previewRef}

--- a/test-app/src/components/docs/DocsSection.tsx
+++ b/test-app/src/components/docs/DocsSection.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback } from "react";
+import { motion } from "framer-motion";
 import { DocsSidebar } from "./DocsSidebar";
 import { ControlsPanel } from "./ControlsPanel";
 import { IntroductionView } from "./IntroductionView";
@@ -18,7 +19,7 @@ export function DocsSection({ backgroundId }: { backgroundId?: string }) {
   const [activePage, setActivePage] = useState(initialPage);
   const initialEntry = DOC_REGISTRY.find((e) => `bg-${e.id}` === initialPage);
   const [params, setParams] = useState<Record<string, unknown>>(
-    initialEntry ? { ...initialEntry.defaults } : {}
+    initialEntry ? { ...initialEntry.defaults } : {},
   );
 
   const bgEntry = DOC_REGISTRY.find((e) => `bg-${e.id}` === activePage);
@@ -47,7 +48,12 @@ export function DocsSection({ backgroundId }: { backgroundId?: string }) {
         <DocsSidebar activePage={activePage} onNavigate={handleNavigate} />
 
         <main className="min-w-0 pt-1 px-8 pb-24 min-h-[calc(100vh-58px)]">
-          <div key={activePage}>
+          <motion.div
+            key={activePage}
+            initial={{ opacity: 0, y: 14 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5, ease: "easeOut" }}
+          >
             {activePage === "introduction" && <IntroductionView />}
             {activePage === "installation" && <InstallationView />}
             {bgEntry && (
@@ -57,7 +63,7 @@ export function DocsSection({ backgroundId }: { backgroundId?: string }) {
                 onParamChange={handleParamChange}
               />
             )}
-          </div>
+          </motion.div>
         </main>
 
         {bgEntry && (

--- a/test-app/src/components/docs/controls/BooleanControl.tsx
+++ b/test-app/src/components/docs/controls/BooleanControl.tsx
@@ -1,3 +1,4 @@
+import { motion } from "framer-motion";
 import type { ParamSchema } from "alg-art-backgrounds";
 
 type BooleanParam = Extract<ParamSchema, { type: "boolean" }>;
@@ -23,9 +24,10 @@ export function BooleanControl({
           background: value ? "var(--color-accent)" : "var(--color-faint)",
         }}
       >
-        <span
-          className="absolute top-0.5 w-4 h-4 rounded-full bg-white transition-transform duration-200"
-          style={{ transform: value ? "translateX(18px)" : "translateX(2px)" }}
+        <motion.span
+          className="absolute top-0.5 w-4 h-4 rounded-full bg-white"
+          animate={{ x: value ? 18 : 2 }}
+          transition={{ type: "spring", stiffness: 500, damping: 35 }}
         />
       </button>
     </div>

--- a/test-app/src/components/home/HeroSection.tsx
+++ b/test-app/src/components/home/HeroSection.tsx
@@ -18,12 +18,7 @@ export function HeroSection() {
     <section className="relative h-svh min-h-150 flex items-center justify-center overflow-hidden">
       {/* Live canvas background */}
       <FlowCurrents
-        style={{
-          position: "absolute",
-          inset: 0,
-          width: "100%",
-          height: "100%",
-        }}
+        style={{ position: "absolute", inset: 0, width: "100%", height: "100%" }}
         count={2200}
         speed={0.75}
         colorWarm="#d97757"
@@ -96,11 +91,13 @@ export function HeroSection() {
       </div>
 
       {/* Scroll indicator */}
-      <div className="hero-scroll absolute bottom-7.5 left-1/2 -translate-x-1/2 flex flex-col items-center gap-1.5 animate-[scrollBounce_2.4s_ease-in-out_infinite]">
-        <div className="w-px h-9 bg-linear-to-b from-muted to-transparent" />
-        <span className="text-[10px] text-muted tracking-[0.14em] font-mono uppercase">
-          scroll
-        </span>
+      <div className="hero-scroll absolute bottom-7.5 left-1/2 -translate-x-1/2 flex flex-col items-center gap-1.5">
+        <div className="animate-[scrollBounce_2.4s_ease-in-out_infinite] flex flex-col items-center gap-1.5">
+          <div className="w-px h-9 bg-linear-to-b from-muted to-transparent" />
+          <span className="text-[10px] text-muted tracking-[0.14em] font-mono uppercase">
+            scroll
+          </span>
+        </div>
       </div>
     </section>
   );

--- a/test-app/src/components/shared/ParamRows.tsx
+++ b/test-app/src/components/shared/ParamRows.tsx
@@ -1,3 +1,4 @@
+import { motion } from "framer-motion";
 import type { ParamSchema } from "alg-art-backgrounds";
 
 export type NumberParam = Extract<ParamSchema, { type: "number" }>;
@@ -89,7 +90,11 @@ export function BooleanRow({
         onClick={() => onChange(param.name, !value)}
         className={`relative w-8 h-4.5 rounded-full border-0 cursor-pointer shrink-0 transition-colors duration-200 ${value ? "bg-accent" : "bg-faint"}`}
       >
-        <span className={`absolute w-3.5 h-3.5 top-0.5 left-0.5 rounded-full bg-white transition-transform duration-200 ${value ? "translate-x-3.5" : "translate-x-0"}`} />
+        <motion.span
+          className="absolute w-3.5 h-3.5 top-0.5 left-0.5 rounded-full bg-white"
+          animate={{ x: value ? 14 : 0 }}
+          transition={{ type: "spring", stiffness: 500, damping: 35 }}
+        />
       </button>
     </div>
   );

--- a/test-app/src/components/studio/BackgroundStudio.tsx
+++ b/test-app/src/components/studio/BackgroundStudio.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useState, useCallback } from "react";
+import { motion } from "framer-motion";
 import type { BackgroundId, AnyParams } from "./types";
 import { BACKGROUNDS, buildInitialParamMap } from "./backgrounds";
 import { Sidebar } from "./Sidebar";
@@ -98,9 +99,12 @@ export function BackgroundStudio({ initialBg }: { initialBg?: string } = {}) {
         {/* Canvas area */}
         <div className="flex-1 flex flex-col overflow-hidden pt-2 p-4 gap-3">
           {/* Canvas card */}
-          <div
+          <motion.div
             ref={previewRef}
-            className="studio-in-1 flex-1 relative overflow-hidden rounded-xl"
+            className="flex-1 relative overflow-hidden rounded-xl"
+            initial={{ opacity: 0, y: 14 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.45, ease: "easeOut", delay: 0.08 }}
           >
             <bg.Component
               {...params}
@@ -112,10 +116,15 @@ export function BackgroundStudio({ initialBg }: { initialBg?: string } = {}) {
               }}
             />
             {showContent && <DemoContentOverlay />}
-          </div>
+          </motion.div>
 
           {/* Bottom bar: tabs left, demo toggle right */}
-          <div className="studio-in-2 shrink-0 flex items-center justify-between px-1">
+          <motion.div
+            className="shrink-0 flex items-center justify-between px-1"
+            initial={{ opacity: 0, y: 14 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.45, ease: "easeOut", delay: 0.18 }}
+          >
             <CanvasExportTabs
               isDownloadingImage={isDownloadingImage}
               isRecordingVideo={isRecordingVideo}
@@ -132,12 +141,14 @@ export function BackgroundStudio({ initialBg }: { initialBg?: string } = {}) {
                 onClick={() => setShowContent((v) => !v)}
                 className={`relative w-9 h-5 rounded-full transition-colors duration-200 cursor-pointer border-0 shrink-0 ${showContent ? "bg-accent" : "bg-faint"}`}
               >
-                <span
-                  className={`absolute w-3.5 h-3.5 top-0.75 left-0.75 rounded-full bg-white transition-transform duration-200 ${showContent ? "translate-x-4" : "translate-x-0"}`}
+                <motion.span
+                  className="absolute w-3.5 h-3.5 top-0.75 left-0.75 rounded-full bg-white"
+                  animate={{ x: showContent ? 16 : 0 }}
+                  transition={{ type: "spring", stiffness: 500, damping: 35 }}
                 />
               </button>
             </div>
-          </div>
+          </motion.div>
         </div>
       </div>
 

--- a/test-app/src/components/studio/CanvasExportTabs.tsx
+++ b/test-app/src/components/studio/CanvasExportTabs.tsx
@@ -1,3 +1,5 @@
+import { motion } from "framer-motion";
+
 interface CanvasExportTabsProps {
   isDownloadingImage: boolean;
   isRecordingVideo: boolean;
@@ -29,16 +31,13 @@ export function CanvasExportTabs({
             }`}
           >
             {tab === "div-video" && isRecordingVideo && (
-              <>
-                <style>{`@keyframes rec-fill{from{transform:scaleX(0)}to{transform:scaleX(1)}}`}</style>
-                <span
-                  className="absolute inset-0 bg-red-500/20 rounded-sm"
-                  style={{
-                    transformOrigin: "left",
-                    animation: "rec-fill 10s linear forwards",
-                  }}
-                />
-              </>
+              <motion.span
+                className="absolute inset-0 bg-red-500/20 rounded-sm"
+                style={{ transformOrigin: "left" }}
+                initial={{ scaleX: 0 }}
+                animate={{ scaleX: 1 }}
+                transition={{ duration: 10, ease: "linear" }}
+              />
             )}
             <span className="relative z-10">
               {tab === "image"

--- a/test-app/src/components/studio/Sidebar.tsx
+++ b/test-app/src/components/studio/Sidebar.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { RotateCcw, Share2, ArrowUpRight, ChevronDown, Check } from "lucide-react";
+import { motion } from "framer-motion";
 import type { ParamSchema } from "alg-art-backgrounds";
 import type { BackgroundEntry, AnyParams, BackgroundId } from "./types";
 import {
@@ -48,9 +49,12 @@ export function Sidebar({
   const [copied, setCopied] = useState(false);
 
   return (
-    <aside
+    <motion.aside
       aria-disabled={isDisabled}
-      className={`studio-side-in relative w-64 ml-4 shrink-0 bg-bg flex flex-col ${isDisabled ? "opacity-70" : ""}`}
+      className={`relative w-64 ml-4 shrink-0 bg-bg flex flex-col ${isDisabled ? "opacity-70" : ""}`}
+      initial={{ opacity: 0, x: -18 }}
+      animate={{ opacity: 1, x: 0 }}
+      transition={{ duration: 0.45, ease: "easeOut" }}
     >
       {isDisabled && (
         <div
@@ -85,11 +89,13 @@ export function Sidebar({
             }`}
           >
             <span className="text-[12px] text-ink font-medium">{bg.label}</span>
-            <ChevronDown
-              size={12}
-              aria-hidden="true"
-              className={`text-muted transition-transform duration-200 ${dropdownOpen ? "rotate-180" : ""}`}
-            />
+            <motion.span
+              animate={{ rotate: dropdownOpen ? 180 : 0 }}
+              transition={{ duration: 0.2 }}
+              className="text-muted flex items-center"
+            >
+              <ChevronDown size={12} aria-hidden="true" />
+            </motion.span>
           </button>
 
           {dropdownOpen && (
@@ -207,6 +213,6 @@ export function Sidebar({
           <ArrowUpRight size={13} aria-hidden="true" /> Export Code
         </button>
       </div>
-    </aside>
+    </motion.aside>
   );
 }

--- a/test-app/src/index.css
+++ b/test-app/src/index.css
@@ -124,76 +124,34 @@ input[type="color"]::-moz-color-swatch {
   background: #3a3a50;
 }
 
-/* Hero text reveal animation */
+
+/* Hero entrance animations */
 @keyframes fadeUp {
-  from {
-    opacity: 0;
-    transform: translateY(24px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+  from { opacity: 0; transform: translateY(24px); }
+  to   { opacity: 1; transform: translateY(0); }
 }
 
-.hero-badge {
-  animation: fadeUp 0.6s ease both;
-  animation-delay: 0.1s;
-}
-.hero-h1 {
-  animation: fadeUp 0.6s ease both;
-  animation-delay: 0.25s;
-}
-.hero-sub {
-  animation: fadeUp 0.6s ease both;
-  animation-delay: 0.4s;
-}
-.hero-ctas {
-  animation: fadeUp 0.6s ease both;
-  animation-delay: 0.52s;
-}
-.hero-cmd {
-  animation: fadeUp 0.6s ease both;
-  animation-delay: 0.62s;
-}
-.hero-scroll {
-  animation: fadeUp 0.6s ease both;
-  animation-delay: 0.8s;
-}
+.hero-badge  { animation: fadeUp 0.6s ease both; animation-delay: 0.1s; }
+.hero-h1     { animation: fadeUp 0.6s ease both; animation-delay: 0.25s; }
+.hero-sub    { animation: fadeUp 0.6s ease both; animation-delay: 0.4s; }
+.hero-ctas   { animation: fadeUp 0.6s ease both; animation-delay: 0.52s; }
+.hero-cmd    { animation: fadeUp 0.6s ease both; animation-delay: 0.62s; }
+.hero-scroll { animation: fadeUp 0.6s ease both; animation-delay: 0.8s; }
 
 @keyframes scrollBounce {
-  0%,
-  100% {
-    transform: translateX(-50%) translateY(0);
-  }
-  50% {
-    transform: translateX(-50%) translateY(6px);
-  }
+  0%, 100% { transform: translateY(0); }
+  50%       { transform: translateY(6px); }
+}
+
+@keyframes pulseDot {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%       { opacity: 0.5; transform: scale(0.7); }
 }
 
 /* Gallery card entrance */
 @keyframes cardIn {
-  from {
-    opacity: 0;
-    transform: translateY(32px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-/* Pulse dot */
-@keyframes pulseDot {
-  0%,
-  100% {
-    opacity: 1;
-    transform: scale(1);
-  }
-  50% {
-    opacity: 0.5;
-    transform: scale(0.7);
-  }
+  from { opacity: 0; transform: translateY(32px); }
+  to   { opacity: 1; transform: translateY(0); }
 }
 
 /* Hide scrollbar but keep scrollability */
@@ -204,56 +162,3 @@ input[type="color"]::-moz-color-swatch {
   display: none;
 }
 
-/* Docs page content entrance */
-@keyframes docsIn {
-  from {
-    opacity: 0;
-    transform: translateY(14px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.docs-in {
-  animation: docsIn 0.4s ease both;
-}
-.docs-in-1 {
-  animation: docsIn 0.4s ease both;
-  animation-delay: 0.06s;
-}
-.docs-in-2 {
-  animation: docsIn 0.4s ease both;
-  animation-delay: 0.13s;
-}
-.docs-in-3 {
-  animation: docsIn 0.4s ease both;
-  animation-delay: 0.2s;
-}
-.docs-in-4 {
-  animation: docsIn 0.4s ease both;
-  animation-delay: 0.28s;
-}
-.docs-in-5 {
-  animation: docsIn 0.4s ease both;
-  animation-delay: 0.36s;
-}
-
-/* Studio entrance animations */
-@keyframes studioSideIn {
-  from { opacity: 0; transform: translateX(-18px); }
-  to   { opacity: 1; transform: translateX(0); }
-}
-
-.studio-side-in {
-  animation: studioSideIn 0.45s ease both;
-}
-.studio-in-1 {
-  animation: docsIn 0.45s ease both;
-  animation-delay: 0.08s;
-}
-.studio-in-2 {
-  animation: docsIn 0.45s ease both;
-  animation-delay: 0.18s;
-}


### PR DESCRIPTION
## Summary

- Installs `framer-motion` and replaces CSS keyframes / inline `<style>` injections with Motion primitives across all stateful and page-level animations
- **DocsSection:** page content transitions on `activePage` change via `motion.div` with `key` — fade + slide up, 0.5s
- **Sidebar:** entrance animation via `motion.aside` + spring-based chevron rotation via `motion.span`
- **CanvasExportTabs:** recording progress bar replaced with `motion.span` (removes inline `@keyframes` injection)
- `ParamRows` / `BooleanControl` / `BackgroundStudio`: all boolean toggle knobs use `motion.span` with spring physics
- **App.tsx:** `StudioPage` and `DocsPage` use stable keys (`"studio"` / `"docs"`) so entrance animations don't replay on in-app navigation

One-shot bulk entrances kept as CSS `@keyframes` (compositor thread, no JS overhead on mount):
- **Hero:** `fadeUp` stagger, `pulseDot`, `scrollBounce`
- **Gallery:** `cardIn` with per-card `animationDelay`